### PR TITLE
Define `#respond_to_missing?` instead of `#respond_to?`

### DIFF
--- a/lib/dot_hash/properties.rb
+++ b/lib/dot_hash/properties.rb
@@ -15,8 +15,8 @@ module DotHash
       end
     end
 
-    def respond_to?(key)
-      has_key?(key) or super(key)
+    def respond_to_missing?(key, *)
+      has_key?(key) or super
     end
 
     def to_s

--- a/test/dot_hash/properties_test.rb
+++ b/test/dot_hash/properties_test.rb
@@ -128,5 +128,43 @@ module DotHash
       end
     end
 
+    describe '#method' do
+      before do
+        @properties = Properties.new speed: "100",
+          info: {name: "Eden"},
+          "color" => "#00FFBB"
+      end
+
+      it 'has a capturable method for a simple property' do
+        @properties.method(:speed).call.must_equal "100"
+      end
+
+      it 'has a capturable method for a nested property' do
+        @properties.info.method(:name).call.must_equal "Eden"
+        @properties.method(:info).call.name.must_equal "Eden"
+      end
+
+      it 'has a capturable method for a string property' do
+        @properties.method(:color).call.must_equal "#00FFBB"
+      end
+
+      it 'does not have a capturable method for a missing property' do
+        lambda do
+          @properties.method(:power)
+        end.must_raise(NameError)
+      end
+
+      it 'has a capturable method for public hash methods' do
+        @properties.method(:keys).must_be_kind_of Method
+      end
+
+      it 'has a capturable method for public methods' do
+        hash_method = @properties.method(:hash)
+        hash_method.must_be_kind_of Method
+        # not Object#hash or Properties#hash#hash
+        hash_method.call.wont_be_kind_of Numeric
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Ruby 1.9.2 added support for `#respond_to_missing?`, which allows an
object that defines `#method_missing` to behave more like the object
actually had the methods handled by `#method_missing`.

See also: http://blog.marc-andre.ca/2010/11/15/methodmissing-politely/
